### PR TITLE
:sparkles: WRITE_ENV support

### DIFF
--- a/src/odap/common/config.py
+++ b/src/odap/common/config.py
@@ -3,11 +3,12 @@ import os
 import enum
 import yaml
 from odap.common.utils import get_repository_root_fs_path
-from odap.common.exceptions import ConfigAttributeMissingException
+from odap.common.exceptions import ConfigAttributeMissingException, WriteEnvNotSetException
 
 
 CONFIG_NAME = "config.yaml"
 TIMESTAMP_COLUMN = "timestamp"
+ENV_PLACEHOLDER = "{write_env}"
 Config = Dict[str, Any]
 
 
@@ -16,12 +17,27 @@ class ConfigNamespace(enum.Enum):
     SEGMENT_FACTORY = "segmentfactory"
 
 
+def resolve_env(raw_config: str):
+    env = os.environ.get("WRITE_ENV")
+
+    if ENV_PLACEHOLDER in raw_config and not env:
+        raise WriteEnvNotSetException(
+            f"Config.yaml contains placeholder {ENV_PLACEHOLDER} but env variable WRITE_ENV is not set."
+        )
+
+    if env:
+        raw_config = raw_config.replace(ENV_PLACEHOLDER, env)
+
+    return raw_config
+
+
 def get_config_on_rel_path(*rel_path: str) -> Config:
     base_path = get_repository_root_fs_path()
     config_path = os.path.join(base_path, *rel_path)
 
     with open(config_path, "r", encoding="utf-8") as stream:
-        config = yaml.safe_load(stream)
+        raw_config = resolve_env(stream.read())
+        config = yaml.safe_load(raw_config)
 
     parameters = config.get("parameters", None)
 

--- a/src/odap/common/exceptions.py
+++ b/src/odap/common/exceptions.py
@@ -6,6 +6,10 @@ class InvalidConfigAttributException(Exception):
     pass
 
 
+class WriteEnvNotSetException(Exception):
+    pass
+
+
 class WidgetValueException(Exception):
     pass
 

--- a/src/odap/feature_factory/config.py
+++ b/src/odap/feature_factory/config.py
@@ -35,7 +35,7 @@ def get_entity_primary_key(config: Config) -> str:
 
     primary_entity = next(iter(entities))
 
-    return entities[primary_entity]["id_column"]
+    return entities[primary_entity]["id_column"].lower()
 
 
 def get_features(config: Config):


### PR DESCRIPTION
`{write_env}` placeholder is now supported in `config.yaml`, it takes value from cluster environment variable `WRITE_ENV`.

So for example.:
```
database: "{write_env}_odap_features"
```