### PR TITLE
:sparkles: Enable category per feature

### DIFF
--- a/odap-package/src/odap/feature_factory/metadata.py
+++ b/odap-package/src/odap/feature_factory/metadata.py
@@ -115,6 +115,12 @@ def add_additional_metadata(metadata: FeatureMetadataType, feature_df: DataFrame
     resolve_fillna_with(metadata)
 
 
+def resolve_global_metadata(feature_metadata: FeatureMetadataType, global_metadata: FeatureMetadataType):
+    for key, value in global_metadata.items():
+        if key not in feature_metadata:
+            feature_metadata[key] = value
+
+
 def resolve_metadata(notebook_cells: List[str], feature_path: str, feature_df: DataFrame) -> FeaturesMetadataType:
     raw_metadata = extract_raw_metadata_from_cells(notebook_cells, feature_path)
 
@@ -124,7 +130,7 @@ def resolve_metadata(notebook_cells: List[str], feature_path: str, feature_df: D
     features_metadata = resolve_metadata_templates(feature_df, raw_features)
 
     for metadata in features_metadata:
-        metadata.update(global_metadata)
+        resolve_global_metadata(metadata, global_metadata)
 
         add_additional_metadata(metadata, feature_df, feature_path)
 

--- a/odap-package/src/odap/feature_factory/tests/metadata_test.py
+++ b/odap-package/src/odap/feature_factory/tests/metadata_test.py
@@ -66,6 +66,7 @@ def test_metadata_integration(mocker):
 # MAGIC             "description": "{product} feature2 in {time_window}",
 # MAGIC             "dtype": "double",
 # MAGIC             "tags": ["tag1", "tag2", "tag3"],
+# MAGIC             "category": "not_general",
 # MAGIC         },
 # MAGIC     },
 # MAGIC }
@@ -105,7 +106,7 @@ def test_metadata_integration(mocker):
                 "feature_template": f_template,
                 "description_template": d_template,
                 "extra": {"product": feature.split("_")[0], "time_window": feature.split("_")[-1]},
-                "category": "general",
+                "category": "not_general" if "feature2" in feature else "general",
                 "table": "general_features",
                 "notebook_name": "feature",
                 "notebook_absolute_path": FEATURE_PATH,


### PR DESCRIPTION
Category can be defined per feature -> Per feature category overrides the global one.