### PR TITLE
Multiple configs

### DIFF
--- a/odap-package/src/odap/common/config.py
+++ b/odap-package/src/odap/common/config.py
@@ -48,7 +48,7 @@ def get_config_on_rel_path(*rel_path: str) -> Config:
 
 
 def get_config_namespace(namespace: ConfigNamespace) -> Config:
-    config_path = get_config_rel_path()
+    config_path = get_config_file_name()
     parameters = get_config_on_rel_path(config_path)
 
     config = parameters.get(namespace.value, None)
@@ -59,7 +59,7 @@ def get_config_namespace(namespace: ConfigNamespace) -> Config:
     return config
 
 
-def get_config_rel_path() -> str:
-    path = os.environ.get("CONFIG_PATH")
+def get_config_file_name() -> str:
+    file_path = os.environ.get("ODAP_CONFIG_PATH")
 
-    return path if path else CONFIG_NAME_DEFAULT
+    return file_path if file_path else CONFIG_NAME_DEFAULT

--- a/odap-package/src/odap/common/config.py
+++ b/odap-package/src/odap/common/config.py
@@ -6,7 +6,6 @@ from odap.common.utils import get_project_root_fs_path
 from odap.common.exceptions import ConfigAttributeMissingException, WriteEnvNotSetException
 
 
-CONFIG_NAME = "config.yaml"
 TIMESTAMP_COLUMN = "timestamp"
 ENV_PLACEHOLDER = "{write_env}"
 Config = Dict[str, Any]
@@ -48,7 +47,7 @@ def get_config_on_rel_path(*rel_path: str) -> Config:
 
 
 def get_config_namespace(namespace: ConfigNamespace) -> Config:
-    parameters = get_config_on_rel_path(CONFIG_NAME)
+    parameters = get_config_on_rel_path(os.environ.get("CONFIG_PATH"))
 
     config = parameters.get(namespace.value, None)
 

--- a/odap-package/src/odap/common/config.py
+++ b/odap-package/src/odap/common/config.py
@@ -6,6 +6,7 @@ from odap.common.utils import get_project_root_fs_path
 from odap.common.exceptions import ConfigAttributeMissingException, WriteEnvNotSetException
 
 
+CONFIG_NAME_DEFAULT = "config.yaml"
 TIMESTAMP_COLUMN = "timestamp"
 ENV_PLACEHOLDER = "{write_env}"
 Config = Dict[str, Any]
@@ -47,11 +48,18 @@ def get_config_on_rel_path(*rel_path: str) -> Config:
 
 
 def get_config_namespace(namespace: ConfigNamespace) -> Config:
-    parameters = get_config_on_rel_path(os.environ.get("CONFIG_PATH"))
+    config_path = get_config_rel_path()
+    parameters = get_config_on_rel_path(config_path)
 
     config = parameters.get(namespace.value, None)
 
     if not config:
-        raise ConfigAttributeMissingException(f"'{namespace.value}' not defined in config.yaml")
+        raise ConfigAttributeMissingException(f"'{namespace.value}' not defined in {config_path}")
 
     return config
+
+
+def get_config_rel_path() -> str:
+    path = os.environ.get("CONFIG_PATH")
+
+    return path if path else CONFIG_NAME_DEFAULT

--- a/odap-package/src/odap/segment_factory/config.py
+++ b/odap-package/src/odap/segment_factory/config.py
@@ -1,6 +1,6 @@
 from typing import Dict, Any, List, Optional
 
-from odap.common.config import get_config_on_rel_path, get_config_rel_path, ConfigNamespace
+from odap.common.config import get_config_on_rel_path, get_config_file_name, ConfigNamespace
 from odap.common.utils import get_absolute_api_path, list_folders, concat_catalog_db_table
 from odap.common.exceptions import ConfigAttributeMissingException
 from odap.common.databricks import get_workspace_api
@@ -104,4 +104,4 @@ def get_use_cases() -> List[str]:
 
 
 def get_use_case_config(use_case_name: str) -> Dict[str, Any]:
-    return get_config_on_rel_path(USE_CASES_FOLDER, use_case_name, get_config_rel_path())
+    return get_config_on_rel_path(USE_CASES_FOLDER, use_case_name, get_config_file_name())

--- a/odap-package/src/odap/segment_factory/config.py
+++ b/odap-package/src/odap/segment_factory/config.py
@@ -1,5 +1,6 @@
+import os
 from typing import Dict, Any, List, Optional
-from odap.common.config import get_config_on_rel_path, ConfigNamespace, CONFIG_NAME
+from odap.common.config import get_config_on_rel_path, ConfigNamespace
 from odap.common.utils import get_absolute_api_path, list_folders, concat_catalog_db_table
 from odap.common.exceptions import ConfigAttributeMissingException
 from odap.common.databricks import get_workspace_api
@@ -103,4 +104,4 @@ def get_use_cases() -> List[str]:
 
 
 def get_use_case_config(use_case_name: str) -> Dict[str, Any]:
-    return get_config_on_rel_path(USE_CASES_FOLDER, use_case_name, CONFIG_NAME)
+    return get_config_on_rel_path(USE_CASES_FOLDER, use_case_name, os.environ.get("CONFIG_PATH"))

--- a/odap-package/src/odap/segment_factory/config.py
+++ b/odap-package/src/odap/segment_factory/config.py
@@ -1,6 +1,6 @@
-import os
 from typing import Dict, Any, List, Optional
-from odap.common.config import get_config_on_rel_path, ConfigNamespace
+
+from odap.common.config import get_config_on_rel_path, get_config_rel_path, ConfigNamespace
 from odap.common.utils import get_absolute_api_path, list_folders, concat_catalog_db_table
 from odap.common.exceptions import ConfigAttributeMissingException
 from odap.common.databricks import get_workspace_api
@@ -104,4 +104,4 @@ def get_use_cases() -> List[str]:
 
 
 def get_use_case_config(use_case_name: str) -> Dict[str, Any]:
-    return get_config_on_rel_path(USE_CASES_FOLDER, use_case_name, os.environ.get("CONFIG_PATH"))
+    return get_config_on_rel_path(USE_CASES_FOLDER, use_case_name, get_config_rel_path())

--- a/odap-package/src/odap/segment_factory/segments.py
+++ b/odap-package/src/odap/segment_factory/segments.py
@@ -16,7 +16,6 @@ def write_segment(
     export_id: str,
     segment_factory_config: Dict,
 ):
-
     extended_segment_df = create_dataframe([[export_id]], get_segment_common_fields_schema()).join(df, how="full")
 
     table = get_segment_table(segment_factory_config)

--- a/odap-package/src/odap/segment_factory/use_cases.py
+++ b/odap-package/src/odap/segment_factory/use_cases.py
@@ -4,6 +4,7 @@ from odap.segment_factory.Export import Export
 from odap.common.logger import logger
 from odap.segment_factory.widgets import ALL, UC_EXPORT_SEPARATOR
 
+
 # pylint: disable=too-many-statements
 def create_use_case_export_map(use_case_exports_list: List[str]) -> Dict[str, List[str]]:
     result_dict: Dict[str, List[str]] = {}

--- a/odap-package/src/odap/use_case/config.py
+++ b/odap-package/src/odap/use_case/config.py
@@ -1,4 +1,6 @@
-from odap.common.config import get_config_namespace, get_config_on_rel_path, CONFIG_NAME, ConfigNamespace
+import os
+
+from odap.common.config import get_config_namespace, get_config_on_rel_path, ConfigNamespace
 from odap.common.exceptions import ConfigAttributeMissingException
 from odap.common.utils import concat_catalog_db_table
 from odap.segment_factory.config import USE_CASES_FOLDER, Config
@@ -37,7 +39,7 @@ def get_use_case_table():
 
 def get_use_case_config(use_case: str) -> dict:
     try:
-        config = get_config_on_rel_path(USE_CASES_FOLDER, use_case, CONFIG_NAME)
+        config = get_config_on_rel_path(USE_CASES_FOLDER, use_case, os.environ.get("CONFIG_PATH"))
         config["name"] = use_case
         return config
     except FileNotFoundError:

--- a/odap-package/src/odap/use_case/config.py
+++ b/odap-package/src/odap/use_case/config.py
@@ -1,4 +1,4 @@
-from odap.common.config import get_config_namespace, get_config_on_rel_path, get_config_rel_path, ConfigNamespace
+from odap.common.config import get_config_namespace, get_config_on_rel_path, get_config_file_name, ConfigNamespace
 from odap.common.exceptions import ConfigAttributeMissingException
 from odap.common.utils import concat_catalog_db_table
 from odap.segment_factory.config import USE_CASES_FOLDER, Config
@@ -37,7 +37,7 @@ def get_use_case_table():
 
 def get_use_case_config(use_case: str) -> dict:
     try:
-        config = get_config_on_rel_path(USE_CASES_FOLDER, use_case, get_config_rel_path())
+        config = get_config_on_rel_path(USE_CASES_FOLDER, use_case, get_config_file_name())
         config["name"] = use_case
         return config
     except FileNotFoundError:

--- a/odap-package/src/odap/use_case/config.py
+++ b/odap-package/src/odap/use_case/config.py
@@ -1,6 +1,4 @@
-import os
-
-from odap.common.config import get_config_namespace, get_config_on_rel_path, ConfigNamespace
+from odap.common.config import get_config_namespace, get_config_on_rel_path, get_config_rel_path, ConfigNamespace
 from odap.common.exceptions import ConfigAttributeMissingException
 from odap.common.utils import concat_catalog_db_table
 from odap.segment_factory.config import USE_CASES_FOLDER, Config
@@ -39,7 +37,7 @@ def get_use_case_table():
 
 def get_use_case_config(use_case: str) -> dict:
     try:
-        config = get_config_on_rel_path(USE_CASES_FOLDER, use_case, os.environ.get("CONFIG_PATH"))
+        config = get_config_on_rel_path(USE_CASES_FOLDER, use_case, get_config_rel_path())
         config["name"] = use_case
         return config
     except FileNotFoundError:

--- a/odap-package/src/odap/use_case/functions.py
+++ b/odap-package/src/odap/use_case/functions.py
@@ -1,6 +1,6 @@
 from typing import List, Iterable
 from odap.common.utils import get_project_root_fs_path
-from odap.common.config import get_config_on_rel_path, CONFIG_NAME
+from odap.common.config import get_config_on_rel_path
 from odap.segment_factory.config import USE_CASES_FOLDER
 
 
@@ -17,9 +17,9 @@ def get_unique_segments(config: dict) -> List[str]:
 
 
 def get_unique_attributes(destinations: Iterable[dict]) -> dict:
-    config = get_config_on_rel_path(USE_CASES_FOLDER, get_project_root_fs_path(), CONFIG_NAME)["segmentfactory"][
-        "destinations"
-    ]
+    config = get_config_on_rel_path(USE_CASES_FOLDER, get_project_root_fs_path(), os.environ.get("CONFIG_PATH"))[
+        "segmentfactory"
+    ]["destinations"]
 
     result = {}
     for destination in destinations:

--- a/odap-package/src/odap/use_case/functions.py
+++ b/odap-package/src/odap/use_case/functions.py
@@ -1,8 +1,7 @@
-import os
 from typing import List, Iterable
 
 from odap.common.utils import get_project_root_fs_path
-from odap.common.config import get_config_on_rel_path
+from odap.common.config import get_config_on_rel_path, get_config_rel_path
 from odap.segment_factory.config import USE_CASES_FOLDER
 
 
@@ -19,7 +18,7 @@ def get_unique_segments(config: dict) -> List[str]:
 
 
 def get_unique_attributes(destinations: Iterable[dict]) -> dict:
-    config = get_config_on_rel_path(USE_CASES_FOLDER, get_project_root_fs_path(), os.environ.get("CONFIG_PATH"))[
+    config = get_config_on_rel_path(USE_CASES_FOLDER, get_project_root_fs_path(), get_config_rel_path())[
         "segmentfactory"
     ]["destinations"]
 

--- a/odap-package/src/odap/use_case/functions.py
+++ b/odap-package/src/odap/use_case/functions.py
@@ -1,7 +1,7 @@
 from typing import List, Iterable
 
 from odap.common.utils import get_project_root_fs_path
-from odap.common.config import get_config_on_rel_path, get_config_rel_path
+from odap.common.config import get_config_on_rel_path, get_config_file_name
 from odap.segment_factory.config import USE_CASES_FOLDER
 
 
@@ -18,7 +18,7 @@ def get_unique_segments(config: dict) -> List[str]:
 
 
 def get_unique_attributes(destinations: Iterable[dict]) -> dict:
-    config = get_config_on_rel_path(USE_CASES_FOLDER, get_project_root_fs_path(), get_config_rel_path())[
+    config = get_config_on_rel_path(USE_CASES_FOLDER, get_project_root_fs_path(), get_config_file_name())[
         "segmentfactory"
     ]["destinations"]
 

--- a/odap-package/src/odap/use_case/functions.py
+++ b/odap-package/src/odap/use_case/functions.py
@@ -1,4 +1,6 @@
+import os
 from typing import List, Iterable
+
 from odap.common.utils import get_project_root_fs_path
 from odap.common.config import get_config_on_rel_path
 from odap.segment_factory.config import USE_CASES_FOLDER


### PR DESCRIPTION
Adding an option to specify an environmental variable that would define a relative path (from root) to the YAML config. If not defined, the default is used. 